### PR TITLE
Customer, if existent is not correctly returned after calling updateCard

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -6,7 +6,7 @@ use Exception;
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use Braintree\PaymentMethod;
-use Braintree\PaypalAccount;
+use Braintree\PayPalAccount;
 use InvalidArgumentException;
 use Braintree\TransactionSearch;
 use Illuminate\Support\Collection;
@@ -395,7 +395,7 @@ trait Billable
 
         $paymentMethod = $response->customer->paymentMethods[0];
 
-        $paypalAccount = $paymentMethod instanceof PaypalAccount;
+        $paypalAccount = $paymentMethod instanceof PayPalAccount;
 
         $this->forceFill([
             'braintree_id' => $response->customer->id,

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -52,7 +52,7 @@ trait Billable
      * @param  array  $options
      * @return \Braintree\Transaction
      */
-    public function invoiceForUpcoming($description, $amount, array $options = [])
+    public function tab($description, $amount, array $options = [])
     {
         return $this->charge($amount, array_merge($options, [
             'customFields' => [
@@ -71,7 +71,7 @@ trait Billable
      */
     public function invoiceFor($description, $amount, array $options = [])
     {
-        return $this->invoiceForUpcoming($description, $amount, $options);
+        return $this->tab($description, $amount, $options);
     }
 
     /**

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -52,13 +52,26 @@ trait Billable
      * @param  array  $options
      * @return \Braintree\Transaction
      */
-    public function invoiceFor($description, $amount, array $options = [])
+    public function invoiceForUpcoming($description, $amount, array $options = [])
     {
         return $this->charge($amount, array_merge($options, [
             'customFields' => [
                 'description' => $description,
             ],
         ]));
+    }
+
+    /**
+     * Invoice the customer for the given amount (alias).
+     *
+     * @param  string  $description
+     * @param  int  $amount
+     * @param  array  $options
+     * @return \Braintree\Transaction
+     */
+    public function invoiceFor($description, $amount, array $options = [])
+    {
+        return $this->invoiceForUpcoming($description, $amount, $options);
     }
 
     /**

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Cashier;
 
+use Exception;
+
 class Cashier
 {
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -29,6 +29,13 @@ class Subscription extends Model
     ];
 
     /**
+     * Indicates if the plan change should be prorated.
+     *
+     * @var bool
+     */
+    protected $prorate = true;
+
+    /**
      * Get the user that owns the subscription.
      */
     public function user()
@@ -97,6 +104,18 @@ class Subscription extends Model
     }
 
     /**
+     * Indicate that the plan change should not be prorated.
+     *
+     * @return $this
+     */
+    public function noProrate()
+    {
+        $this->prorate = false;
+
+        return $this;
+    }
+
+    /**
      * Swap the subscription to a new Braintree plan.
      *
      * @param  string  $plan
@@ -115,7 +134,7 @@ class Subscription extends Model
 
         $plan = BraintreeService::findPlan($plan);
 
-        if ($this->wouldChangeBillingFrequency($plan)) {
+        if ($this->wouldChangeBillingFrequency($plan) && $this->prorate) {
             return $this->swapAcrossFrequencies($plan);
         }
 
@@ -127,7 +146,7 @@ class Subscription extends Model
             'neverExpires' => true,
             'numberOfBillingCycles' => null,
             'options' => [
-                'prorateCharges' => true,
+                'prorateCharges' => $this->prorate,
             ],
         ]);
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -29,7 +29,7 @@ class Subscription extends Model
     ];
 
     /**
-     * Indicates if the plan change should be prorated.
+     * Indicates plan changes should be prorated.
      *
      * @var bool
      */
@@ -101,18 +101,6 @@ class Subscription extends Model
         } else {
             return false;
         }
-    }
-
-    /**
-     * Indicate that the plan change should not be prorated.
-     *
-     * @return $this
-     */
-    public function noProrate()
-    {
-        $this->prorate = false;
-
-        return $this;
     }
 
     /**
@@ -379,6 +367,18 @@ class Subscription extends Model
         ]);
 
         $this->fill(['ends_at' => null])->save();
+
+        return $this;
+    }
+
+    /**
+     * Indicate that plan changes should not be prorated.
+     *
+     * @return $this
+     */
+    public function noProrate()
+    {
+        $this->prorate = false;
 
         return $this;
     }


### PR DESCRIPTION
On getBraintreeCustomer(), a customer wasn't correctly returned if the
card data was updated, giving an exception later as the customer haven't
any payment methods assigned.